### PR TITLE
feat: ツイート抽出・マージ機能の拡張（ユーザー名・本文URL対応）

### DIFF
--- a/src/merge_all_txt_to_csv.py
+++ b/src/merge_all_txt_to_csv.py
@@ -16,8 +16,13 @@ def parse_txt_to_tweets(txt_file_path):
     for line in lines:
         line = line.strip()
 
+        # ユーザー名の行を検出
+        if line.startswith('ユーザー名: '):
+            user_name = line.replace('ユーザー名: ', '')
+            current_tweet['user_name'] = user_name
+
         # 日時の行を検出
-        if line.startswith('日時: '):
+        elif line.startswith('日時: '):
             datetime_str = line.replace('日時: ', '')
             current_tweet['datetime'] = datetime_str
             # 日時をパースしてソート用のタイムスタンプを作成
@@ -96,10 +101,11 @@ def merge_all_txt_to_csv():
     # CSVファイルに書き込み
     with open(csv_file, 'w', encoding='utf-8', newline='') as f:
         writer = csv.writer(f)
-        writer.writerow(['日時', 'URL', 'ツイート内容', '元ファイル'])
+        writer.writerow(['ユーザー名', '日時', 'URL', 'ツイート内容', '元ファイル'])
 
         for tweet in all_tweets:
             writer.writerow([
+                tweet.get('user_name', ''),
                 tweet.get('datetime', ''),
                 tweet.get('url', ''),
                 tweet.get('text', ''),


### PR DESCRIPTION
- ツイート本文中やカードリンク等に含まれる全てのURL（t.co含む）を抽出し、本文末尾に追加\n- ツイートごとにユーザー名（表示名）を抽出し、テキスト・コンソール・CSV出力に反映\n- マージCSVの出力項目に「ユーザー名」列を追加\n- ツイート抽出後、最後のツイート日時を `until:YYYY-MM-DD_HH:MM:SS_JST` 形式で表示\n- 既存テストを全てパス（新仕様の個別テストは未追加）\n\n# twitter-html-extractor