### PR TITLE
feat: キーワードタイプ別のprefixフォルダ機能と分離マージ機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,15 @@ data/input/bk/*.html
 data/output/txt/bk/*.txt
 data/output/csv/bk/*.csv
 
+# prefix別フォルダのデータファイル（chikirinなど）
+data/input/*/*.html
+data/output/*/txt/*.txt
+data/output/*/csv/*.csv
+data/output/*/json/*.json
+data/input/*/bk/*.html
+data/output/*/txt/bk/*.txt
+data/output/*/csv/bk/*.csv
+
 # サンプルファイルは除外しない
 !data/input/sample.html
 !data/output/txt/sample.txt

--- a/config.py
+++ b/config.py
@@ -12,7 +12,17 @@ SEARCH_KEYWORDS = {
     'default': 'dtv ビザ',
     'thai': 'dtv タイ',
     'en': 'dtv visa',
+    'chikirin': '#ちきりんセレクトTV',
     'custom': None  # カスタムキーワード用
+}
+
+# キーワードタイプとprefixのマッピング
+KEYWORD_PREFIX_MAPPING = {
+    'default': None,
+    'thai': None,
+    'en': None,
+    'chikirin': 'chikirin',
+    'custom': None
 }
 
 # ファイルパス設定
@@ -21,6 +31,26 @@ OUTPUT_FOLDER = "data/output"
 TXT_OUTPUT_FOLDER = "data/output/txt"
 JSON_OUTPUT_FOLDER = "data/output/json"
 CSV_OUTPUT_FOLDER = "data/output/csv"
+
+# prefix別のフォルダ設定
+def get_prefix_folders(prefix):
+    """prefixに基づいてフォルダパスを取得"""
+    if prefix is None:
+        return {
+            'input': INPUT_FOLDER,
+            'output': OUTPUT_FOLDER,
+            'txt': TXT_OUTPUT_FOLDER,
+            'json': JSON_OUTPUT_FOLDER,
+            'csv': CSV_OUTPUT_FOLDER
+        }
+    else:
+        return {
+            'input': f"data/input/{prefix}",
+            'output': f"data/output/{prefix}",
+            'txt': f"data/output/{prefix}/txt",
+            'json': f"data/output/{prefix}/json",
+            'csv': f"data/output/{prefix}/csv"
+        }
 
 # 日付形式設定
 DATE_FORMAT = '%Y-%m-%d'

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,36 @@ python main.py html 250706 --keyword-type chikirin
 - 設定ファイルのキーワード種類やカスタムキーワードで検索可能
 - `chikirin`キーワードタイプを使用すると、専用フォルダ（`data/input/chikirin/`、`data/output/chikirin/`）にファイルが保存されます
 
+### キーワードタイプ別フォルダ機能
+
+キーワードタイプを指定すると、自動的に専用フォルダが作成され、データが分離管理されます：
+
+- **デフォルトキーワード**: `data/input/`, `data/output/txt/`, `data/output/json/`, `data/output/csv/`
+- **chikirin キーワード**: `data/input/chikirin/`, `data/output/chikirin/txt/`, `data/output/chikirin/json/`, `data/output/chikirin/csv/`
+- **その他のキーワード**: `data/input/{prefix}/`, `data/output/{prefix}/txt/`, `data/output/{prefix}/json/`, `data/output/{prefix}/csv/`
+
+この機能により、異なる検索条件のデータを混在させることなく、整理して管理できます。
+
+### マージ機能
+
+```bash
+# デフォルトキーワードタイプのファイルをマージ
+python main.py merge
+
+# 特定キーワードタイプのみマージ
+python main.py merge --keyword-type chikirin
+python main.py merge --keyword-type thai
+python main.py merge --keyword-type en
+```
+
+マージ機能では、指定されたキーワードタイプの txt ファイルのみを対象として CSV ファイルを作成します：
+
+- **デフォルトキーワード**: `data/output/csv/all_tweets.csv`
+- **chikirin キーワード**: `data/output/chikirin/csv/chikirin_tweets.csv`
+- **その他のキーワード**: `data/output/{prefix}/csv/{keyword_type}_tweets.csv`
+
+これにより、キーワードタイプ別に分離されたデータ分析が可能になります。
+
 ---
 
 ## コマンド例・検索クエリ・前提条件
@@ -118,7 +148,9 @@ python main.py html --no-date
 - **extract コマンド**
   - `python main.py extract <YYMMDD>`: 既存 HTML から抽出のみ
 - **merge コマンド**
-  - `python main.py merge`: 全ファイルをマージして CSV 作成
+  - `python main.py merge`: デフォルトキーワードタイプのファイルをマージして CSV 作成
+  - `python main.py merge --keyword-type <type>`: 特定キーワードタイプのみマージ
+  - 使用可能なキーワードタイプ: `default`, `thai`, `en`, `chikirin`, `custom`
 
 ---
 
@@ -195,6 +227,12 @@ twitter-html-extractor/
 
 ## 更新履歴
 
+- v1.6.0: キーワードタイプ別フォルダ機能と分離マージ機能の実装
+  - キーワードタイプ指定時に prefix 別フォルダが自動作成される機能を実装
+  - HTML ファイルの自動検出機能（prefix 別フォルダ優先）を実装
+  - マージ機能に--keyword-type オプションを追加（特定キーワードタイプのみマージ）
+  - 分離 CSV ファイル作成機能を実装（all_tweets.csv, chikirin_tweets.csv 等）
+  - prefix 別データフォルダ用の gitignore パターンを追加
 - v1.5.0: chikirin キーワードタイプの追加と prefix 別フォルダ機能
   - "#ちきりんセレクト TV"キーワードと"chikirin"prefix を追加
   - prefix 別の専用フォルダ作成機能（`data/input/chikirin/`、`data/output/chikirin/`）

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,18 +54,21 @@ python main.py html --no-date
 ```bash
 python main.py html 250706 --keyword-type en
 python main.py html 250706 --search-keyword "ニュース ビザ"
+python main.py html 250706 --keyword-type chikirin
 ```
 
 - 設定ファイルのキーワード種類やカスタムキーワードで検索可能
+- `chikirin`キーワードタイプを使用すると、専用フォルダ（`data/input/chikirin/`、`data/output/chikirin/`）にファイルが保存されます
 
 ---
 
 ## コマンド例・検索クエリ・前提条件
 
-| コマンド例                      | 変換される検索クエリ                                                   | 前提条件（クリップボード等）                                      |
-| ------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `python main.py html 250706`    | `since:2025-07-06_00:00:00_JST until:2025-07-06_23:59:59_JST dtv ビザ` | なし（コマンド引数のみで OK）                                     |
-| `python main.py html --no-date` | `until:2025-07-06_12:34:56_JST dtv ビザ`                               | クリップボードに`until:YYYY-MM-DD_HH:MM:SS_JST`形式の文字列が必要 |
+| コマンド例                                           | 変換される検索クエリ                                                              | 前提条件（クリップボード等）                                      |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `python main.py html 250706`                         | `since:2025-07-06_00:00:00_JST until:2025-07-06_23:59:59_JST dtv ビザ`            | なし（コマンド引数のみで OK）                                     |
+| `python main.py html --no-date`                      | `until:2025-07-06_12:34:56_JST dtv ビザ`                                          | クリップボードに`until:YYYY-MM-DD_HH:MM:SS_JST`形式の文字列が必要 |
+| `python main.py html 250706 --keyword-type chikirin` | `since:2025-07-06_00:00:00_JST until:2025-07-06_23:59:59_JST #ちきりんセレクトTV` | なし（コマンド引数のみで OK）                                     |
 
 ---
 
@@ -159,10 +162,15 @@ twitter-html-extractor/
 │   └── create_twitter_html_auto.py
 ├── data/                         # データフォルダ
 │   ├── input/                    # 入力ファイル（スクリプトで自動生成）
+│   │   └── chikirin/            # chikirinキーワード用専用フォルダ
 │   └── output/                   # 出力ファイル
 │       ├── txt/                  # テキストファイル
 │       ├── json/                 # JSONファイル
-│       └── csv/                  # CSVファイル
+│       ├── csv/                  # CSVファイル
+│       └── chikirin/            # chikirinキーワード用専用フォルダ
+│           ├── txt/              # テキストファイル
+│           ├── json/             # JSONファイル
+│           └── csv/              # CSVファイル
 ├── docs/                         # ドキュメント
 │   └── README.md
 ├── tests/                        # テストファイル
@@ -187,6 +195,12 @@ twitter-html-extractor/
 
 ## 更新履歴
 
+- v1.5.0: chikirin キーワードタイプの追加と prefix 別フォルダ機能
+  - "#ちきりんセレクト TV"キーワードと"chikirin"prefix を追加
+  - prefix 別の専用フォルダ作成機能（`data/input/chikirin/`、`data/output/chikirin/`）
+  - HTML 作成、抽出、マージ処理で prefix 別フォルダを自動検出・使用
+  - 設定ファイルにキーワードタイプと prefix のマッピング機能を追加
+  - テストケースの追加と更新
 - v1.4.0: html コマンドの動作改善と--no-date オプションの追加
   - 通常の html コマンドで日付引数が必須に変更（YYMMDD 形式のみ）
   - `--no-since`を`--no-date`にリネーム（より分かりやすく）

--- a/main.py
+++ b/main.py
@@ -12,13 +12,14 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 from extract_tweets_from_html import main as extract_main
 from merge_all_txt_to_csv import merge_all_txt_to_csv
 from create_twitter_html_auto import main as create_twitter_html_auto_main
+import config
 
 def main():
     """メインエントリーポイント"""
     if len(sys.argv) < 2:
         print("使用方法:")
         print("  ツイート抽出: python main.py extract <日付>")
-        print("  マージ実行:   python main.py merge")
+        print("  マージ実行:   python main.py merge [--keyword-type <type>]")
         print("  HTML作成:     python main.py html <日付> [オプション]")
         print("  Twitter自動化: python main.py auto <日付>")
         print("")
@@ -27,9 +28,13 @@ def main():
         print("  --keyword-type <type>: 検索キーワードの種類 (default, thai, en, chikirin, custom)")
         print("  --search-keyword <keyword>: カスタム検索キーワード")
         print("")
+        print("マージ実行のオプション:")
+        print("  --keyword-type <type>: 特定キーワードタイプのみマージ (default, thai, en, chikirin, custom)")
+        print("")
         print("例:")
         print("  python main.py extract 250706")
         print("  python main.py merge")
+        print("  python main.py merge --keyword-type chikirin")
         print("  python main.py html 250701")
         print("  python main.py html --no-date")
         print("  python main.py html --no-date --keyword-type thai")
@@ -52,7 +57,23 @@ def main():
         extract_main()
 
     elif command == "merge":
-        merge_all_txt_to_csv()
+        # オプション引数の解析
+        keyword_type = 'default'
+
+        i = 2
+        while i < len(sys.argv):
+            if sys.argv[i] == '--keyword-type' and i + 1 < len(sys.argv):
+                keyword_type = sys.argv[i + 1]
+                i += 1
+            i += 1
+
+        # キーワードタイプの検証
+        if keyword_type not in config.KEYWORD_PREFIX_MAPPING:
+            print(f"エラー: 無効なキーワードタイプ '{keyword_type}'")
+            print(f"使用可能なキーワードタイプ: {', '.join(config.KEYWORD_PREFIX_MAPPING.keys())}")
+            sys.exit(1)
+
+        merge_all_txt_to_csv(keyword_type)
 
     elif command == "html":
         # オプション引数の解析

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def main():
         print("")
         print("HTML作成のオプション:")
         print("  --no-date: 日付指定なしで検索（untilは指定、日付引数不要）")
-        print("  --keyword-type <type>: 検索キーワードの種類 (default, thai, en, custom)")
+        print("  --keyword-type <type>: 検索キーワードの種類 (default, thai, en, chikirin, custom)")
         print("  --search-keyword <keyword>: カスタム検索キーワード")
         print("")
         print("例:")
@@ -34,6 +34,7 @@ def main():
         print("  python main.py html --no-date")
         print("  python main.py html --no-date --keyword-type thai")
         print("  python main.py html 250701 --search-keyword 'ニュース ビザ'")
+        print("  python main.py html 250701 --keyword-type chikirin")
         print("  python main.py auto 2025-01-15")
         sys.exit(1)
 

--- a/src/create_twitter_html_auto.py
+++ b/src/create_twitter_html_auto.py
@@ -60,7 +60,7 @@ def copy_html_with_extension(extension_button_pos):
     html_content = pyperclip.paste()
     return html_content
 
-def save_html_to_file(html_content, date_str):
+def save_html_to_file(html_content, date_str, keyword_type='default'):
     # date_str: '2025-07-09' または '250709' など
     if '-' in date_str:  # YYYY-MM-DD形式
         # 2025-07-10 -> 250710
@@ -79,8 +79,14 @@ def save_html_to_file(html_content, date_str):
         print(f"エラー: 不正な日付形式です: {date_str}")
         return None
 
-    output_dir = "data/input"
+    # prefixに基づいてフォルダを決定
+    prefix = config.KEYWORD_PREFIX_MAPPING.get(keyword_type)
+    folders = config.get_prefix_folders(prefix)
+    output_dir = folders['input']
+
+    # フォルダを作成
     os.makedirs(output_dir, exist_ok=True)
+
     filename = f"{yymmdd}.html"
     filepath = os.path.join(output_dir, filename)
     with open(filepath, 'w', encoding='utf-8') as f:
@@ -94,7 +100,7 @@ def main(date_str=None, search_keyword=None, use_date=True, keyword_type='defaul
         parser.add_argument('date', help='検索対象の日付 (YYMMDD形式)')
         parser.add_argument('--search-keyword', default=None,
                            help='検索キーワード (デフォルト: 設定ファイルから取得)')
-        parser.add_argument('--keyword-type', choices=['default', 'thai', 'en', 'custom'],
+        parser.add_argument('--keyword-type', choices=['default', 'thai', 'en', 'chikirin', 'custom'],
                            default='default', help='検索キーワードの種類')
         parser.add_argument('--no-date', action='store_true',
                            help='日付指定なしで検索する')
@@ -206,7 +212,7 @@ def main(date_str=None, search_keyword=None, use_date=True, keyword_type='defaul
 
         if html_content:
             # HTMLファイルに保存
-            filepath = save_html_to_file(html_content, date_str)
+            filepath = save_html_to_file(html_content, date_str, keyword_type)
             print(f"処理が完了しました！ファイル: {filepath}")
             return filepath  # 成功時はファイルパスを返す
         else:

--- a/src/extract_tweets_from_html.py
+++ b/src/extract_tweets_from_html.py
@@ -198,40 +198,31 @@ def main():
     html_file = None
     prefix = None
 
-    # まず通常のフォルダで検索
-    input_folder = config.INPUT_FOLDER
-    html_file = os.path.join(input_folder, f"{args.date}.html")
+    # まずprefix別フォルダで検索（優先）
+    for keyword_type, p in config.KEYWORD_PREFIX_MAPPING.items():
+        if p is not None:
+            folders = config.get_prefix_folders(p)
+            test_html_file = os.path.join(folders['input'], f"{args.date}.html")
+            if os.path.exists(test_html_file):
+                html_file = test_html_file
+                prefix = p  # prefixを設定
+                break
 
-    if not os.path.exists(html_file):
-        # 通常のフォルダにない場合、prefix別フォルダを検索
-        for keyword_type, prefix in config.KEYWORD_PREFIX_MAPPING.items():
-            if prefix is not None:
-                folders = config.get_prefix_folders(prefix)
-                test_html_file = os.path.join(folders['input'], f"{args.date}.html")
-                if os.path.exists(test_html_file):
-                    html_file = test_html_file
-                    break
+    # prefix別フォルダにない場合、通常のフォルダで検索
+    if html_file is None:
+        input_folder = config.INPUT_FOLDER
+        html_file = os.path.join(input_folder, f"{args.date}.html")
+        prefix = None  # 通常フォルダの場合はprefixなし
 
     if html_file is None or not os.path.exists(html_file):
         print(f"エラー: ファイル '{args.date}.html' が見つかりません。")
         print("以下の場所を確認してください:")
-        print(f"  - {config.INPUT_FOLDER}/")
-        for keyword_type, prefix in config.KEYWORD_PREFIX_MAPPING.items():
-            if prefix is not None:
-                folders = config.get_prefix_folders(prefix)
-                print(f"  - {folders['input']}/")
-        sys.exit(1)
-
-    # prefixを決定
-    if html_file.startswith(config.INPUT_FOLDER):
-        prefix = None
-    else:
         for keyword_type, p in config.KEYWORD_PREFIX_MAPPING.items():
             if p is not None:
                 folders = config.get_prefix_folders(p)
-                if html_file.startswith(folders['input']):
-                    prefix = p
-                    break
+                print(f"  - {folders['input']}/")
+        print(f"  - {config.INPUT_FOLDER}/")
+        sys.exit(1)
 
     # 出力フォルダの設定
     folders = config.get_prefix_folders(prefix)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,43 @@ class TestConfig(unittest.TestCase):
         self.assertIn('default', config.SEARCH_KEYWORDS)
         self.assertIn('thai', config.SEARCH_KEYWORDS)
         self.assertIn('en', config.SEARCH_KEYWORDS)
+        self.assertIn('chikirin', config.SEARCH_KEYWORDS)
         self.assertIn('custom', config.SEARCH_KEYWORDS)
+
+    def test_keyword_prefix_mapping(self):
+        """キーワードタイプとprefixのマッピングが正しく設定されていることを確認"""
+        self.assertIn('default', config.KEYWORD_PREFIX_MAPPING)
+        self.assertIn('thai', config.KEYWORD_PREFIX_MAPPING)
+        self.assertIn('en', config.KEYWORD_PREFIX_MAPPING)
+        self.assertIn('chikirin', config.KEYWORD_PREFIX_MAPPING)
+        self.assertIn('custom', config.KEYWORD_PREFIX_MAPPING)
+
+        # chikirinのprefixが正しく設定されていることを確認
+        self.assertEqual(config.KEYWORD_PREFIX_MAPPING['chikirin'], 'chikirin')
+
+        # 他のキーワードタイプはprefixがNoneであることを確認
+        self.assertIsNone(config.KEYWORD_PREFIX_MAPPING['default'])
+        self.assertIsNone(config.KEYWORD_PREFIX_MAPPING['thai'])
+        self.assertIsNone(config.KEYWORD_PREFIX_MAPPING['en'])
+        self.assertIsNone(config.KEYWORD_PREFIX_MAPPING['custom'])
+
+    def test_get_prefix_folders(self):
+        """prefix別フォルダ取得機能のテスト"""
+        # prefixなしの場合
+        folders = config.get_prefix_folders(None)
+        self.assertEqual(folders['input'], config.INPUT_FOLDER)
+        self.assertEqual(folders['output'], config.OUTPUT_FOLDER)
+        self.assertEqual(folders['txt'], config.TXT_OUTPUT_FOLDER)
+        self.assertEqual(folders['json'], config.JSON_OUTPUT_FOLDER)
+        self.assertEqual(folders['csv'], config.CSV_OUTPUT_FOLDER)
+
+        # chikirin prefixの場合
+        folders = config.get_prefix_folders('chikirin')
+        self.assertEqual(folders['input'], 'data/input/chikirin')
+        self.assertEqual(folders['output'], 'data/output/chikirin')
+        self.assertEqual(folders['txt'], 'data/output/chikirin/txt')
+        self.assertEqual(folders['json'], 'data/output/chikirin/json')
+        self.assertEqual(folders['csv'], 'data/output/chikirin/csv')
 
     def test_default_search_keyword(self):
         """デフォルト検索キーワードが設定されていることを確認"""

--- a/tests/test_create_twitter_html_auto.py
+++ b/tests/test_create_twitter_html_auto.py
@@ -252,7 +252,7 @@ class TestCreateTwitterHtmlAuto(unittest.TestCase):
         from src.create_twitter_html_auto import main
 
         # 各キーワードタイプをテスト
-        keyword_types = ['default', 'thai', 'en', 'custom']
+        keyword_types = ['default', 'thai', 'en', 'chikirin', 'custom']
 
         for keyword_type in keyword_types:
             with self.subTest(keyword_type=keyword_type):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -108,6 +108,44 @@ class TestIntegration(unittest.TestCase):
             self.assertEqual(keyword_type, 'thai')
             self.assertIsNone(search_keyword)
 
+    @patch('src.create_twitter_html_auto.main')
+    def test_main_html_with_chikirin_keyword_type(self, mock_create_html):
+        """main.pyのhtmlコマンドで--keyword-type chikirinオプションをテスト"""
+        # テスト用のsys.argvを設定
+        test_args = ['main.py', 'html', '250513', '--keyword-type', 'chikirin']
+
+        with patch('sys.argv', test_args):
+            # main.pyのhtmlコマンド部分をテスト
+            yymmdd = test_args[2]
+            if len(yymmdd) == 6:
+                year = 2000 + int(yymmdd[:2])
+                date_str = f"{year:04d}-{yymmdd[2:4]}-{yymmdd[4:6]}"
+            else:
+                date_str = None
+
+            # オプション解析
+            use_since = True
+            keyword_type = 'default'
+            search_keyword = None
+
+            i = 3
+            while i < len(test_args):
+                if test_args[i] == '--no-since':
+                    use_since = False
+                elif test_args[i] == '--keyword-type' and i + 1 < len(test_args):
+                    keyword_type = test_args[i + 1]
+                    i += 1
+                elif test_args[i] == '--search-keyword' and i + 1 < len(test_args):
+                    search_keyword = test_args[i + 1]
+                    i += 1
+                i += 1
+
+            # 結果を確認
+            self.assertEqual(date_str, "2025-05-13")
+            self.assertTrue(use_since)
+            self.assertEqual(keyword_type, 'chikirin')
+            self.assertIsNone(search_keyword)
+
     def test_search_query_actual_behavior(self):
         """実際の検索クエリ生成動作をテスト"""
         import config


### PR DESCRIPTION
## 概要
キーワードタイプ別のprefixフォルダ機能と分離マージ機能を実装しました。

## 主な変更点
- キーワードタイプ指定時にprefix別フォルダ（例：data/input/chikirin/）が自動作成
- マージ機能で--keyword-typeオプションにより特定キーワードタイプのみを対象とした分離CSVファイル作成
- chikirinキーワードタイプとprefixマッピングを追加
- .gitignoreにprefix別フォルダのデータファイル除外パターンを追加

## 技術的な変更
- config.py: KEYWORD_PREFIX_MAPPINGとget_prefix_folders()関数を追加
- main.py: mergeコマンドに--keyword-typeオプションを追加
- src/: 各モジュールでprefix別フォルダ対応を実装
- tests/: chikirinキーワードタイプのテストケースを追加
- docs/README.md: 新機能の詳細説明を追加