### PR TITLE
feat: --keyword-type に -k 短縮オプションを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,13 +52,20 @@ python main.py html --no-date
 ### キーワード指定
 
 ```bash
-python main.py html 250706 --keyword-type en
+# キーワードタイプを指定（--keyword-type または短縮形 -k が使用可能）
+python main.py html 250706 --keyword-type en  # 完全形
+python main.py html 250706 -k en             # 短縮形
+
+# カスタムキーワードで検索
 python main.py html 250706 --search-keyword "ニュース ビザ"
-python main.py html 250706 --keyword-type chikirin
+
+# キーワードタイプに chikirin を指定（短縮形 -k を使用）
+python main.py html 250706 -k chikirin
 ```
 
-- 設定ファイルのキーワード種類やカスタムキーワードで検索可能
-- `chikirin`キーワードタイプを使用すると、専用フォルダ（`data/input/chikirin/`、`data/output/chikirin/`）にファイルが保存されます
+- `--keyword-type` の代わりに短縮形の `-k` が使用できます（例：`-k en`）
+- 設定ファイルで定義されたキーワードタイプか、`--search-keyword` で直接キーワードを指定可能
+- `chikirin` などのキーワードタイプを指定すると、専用フォルダ（`data/input/chikirin/`、`data/output/chikirin/`）にファイルが保存され、データが整理されます
 
 ### キーワードタイプ別フォルダ機能
 
@@ -77,9 +84,9 @@ python main.py html 250706 --keyword-type chikirin
 python main.py merge
 
 # 特定キーワードタイプのみマージ
-python main.py merge --keyword-type chikirin
-python main.py merge --keyword-type thai
-python main.py merge --keyword-type en
+python main.py merge --keyword-type chikirin  # または -k chikirin
+python main.py merge -k thai  # --keyword-type の代わりに -k が使えます
+python main.py merge -k en
 ```
 
 マージ機能では、指定されたキーワードタイプの txt ファイルのみを対象として CSV ファイルを作成します：
@@ -98,7 +105,7 @@ python main.py merge --keyword-type en
 | ---------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | `python main.py html 250706`                         | `since:2025-07-06_00:00:00_JST until:2025-07-06_23:59:59_JST dtv ビザ`            | なし（コマンド引数のみで OK）                                     |
 | `python main.py html --no-date`                      | `until:2025-07-06_12:34:56_JST dtv ビザ`                                          | クリップボードに`until:YYYY-MM-DD_HH:MM:SS_JST`形式の文字列が必要 |
-| `python main.py html 250706 --keyword-type chikirin` | `since:2025-07-06_00:00:00_JST until:2025-07-06_23:59:59_JST #ちきりんセレクトTV` | なし（コマンド引数のみで OK）                                     |
+| `python main.py html 250706 -k chikirin` | `since:2025-07-06_00:00:00_JST until:2025-07-06_23:59:59_JST #ちきりんセレクトTV` | なし（コマンド引数のみで OK）<br>`-k` は `--keyword-type` の短縮形 |
 
 ---
 
@@ -149,7 +156,7 @@ python main.py html --no-date
   - `python main.py extract <YYMMDD>`: 既存 HTML から抽出のみ
 - **merge コマンド**
   - `python main.py merge`: デフォルトキーワードタイプのファイルをマージして CSV 作成
-  - `python main.py merge --keyword-type <type>`: 特定キーワードタイプのみマージ
+  - `python main.py merge --keyword-type <type>` または `-k <type>`: 特定キーワードタイプのみマージ
   - 使用可能なキーワードタイプ: `default`, `thai`, `en`, `chikirin`, `custom`
 
 ---

--- a/main.py
+++ b/main.py
@@ -62,7 +62,7 @@ def main():
 
         i = 2
         while i < len(sys.argv):
-            if sys.argv[i] == '--keyword-type' and i + 1 < len(sys.argv):
+            if (sys.argv[i] == '--keyword-type' or sys.argv[i] == '-k') and i + 1 < len(sys.argv):
                 keyword_type = sys.argv[i + 1]
                 i += 1
             i += 1
@@ -85,7 +85,7 @@ def main():
         while i < len(sys.argv):
             if sys.argv[i] == '--no-date':
                 use_date = False
-            elif sys.argv[i] == '--keyword-type' and i + 1 < len(sys.argv):
+            elif (sys.argv[i] == '--keyword-type' or sys.argv[i] == '-k') and i + 1 < len(sys.argv):
                 keyword_type = sys.argv[i + 1]
                 i += 1
             elif sys.argv[i] == '--search-keyword' and i + 1 < len(sys.argv):

--- a/src/create_twitter_html_auto.py
+++ b/src/create_twitter_html_auto.py
@@ -100,7 +100,7 @@ def main(date_str=None, search_keyword=None, use_date=True, keyword_type='defaul
         parser.add_argument('date', help='検索対象の日付 (YYMMDD形式)')
         parser.add_argument('--search-keyword', default=None,
                            help='検索キーワード (デフォルト: 設定ファイルから取得)')
-        parser.add_argument('--keyword-type', choices=['default', 'thai', 'en', 'chikirin', 'custom'],
+        parser.add_argument('--keyword-type', '-k', choices=['default', 'thai', 'en', 'chikirin', 'custom'],
                            default='default', help='検索キーワードの種類')
         parser.add_argument('--no-date', action='store_true',
                            help='日付指定なしで検索する')

--- a/src/extract_tweets_from_html.py
+++ b/src/extract_tweets_from_html.py
@@ -191,7 +191,7 @@ def main():
     # コマンドライン引数の解析
     parser = argparse.ArgumentParser(description='HTMLファイルからツイートを抽出します')
     parser.add_argument('date', help='日付（例: 250706, 250624）')
-    parser.add_argument('--keyword-type', help='キーワードタイプ (default, thai, en, chikirin, custom)', default='default')
+    parser.add_argument('--keyword-type', '-k', help='キーワードタイプ (default, thai, en, chikirin, custom)', default='default')
 
     args = parser.parse_args()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -94,7 +94,7 @@ class TestIntegration(unittest.TestCase):
             while i < len(test_args):
                 if test_args[i] == '--no-since':
                     use_since = False
-                elif test_args[i] == '--keyword-type' and i + 1 < len(test_args):
+                elif (test_args[i] == '--keyword-type' or test_args[i] == '-k') and i + 1 < len(test_args):
                     keyword_type = test_args[i + 1]
                     i += 1
                 elif test_args[i] == '--search-keyword' and i + 1 < len(test_args):
@@ -132,7 +132,39 @@ class TestIntegration(unittest.TestCase):
             while i < len(test_args):
                 if test_args[i] == '--no-since':
                     use_since = False
-                elif test_args[i] == '--keyword-type' and i + 1 < len(test_args):
+                elif (test_args[i] == '--keyword-type' or test_args[i] == '-k') and i + 1 < len(test_args):
+                    keyword_type = test_args[i + 1]
+                    i += 1
+                elif test_args[i] == '--search-keyword' and i + 1 < len(test_args):
+                    search_keyword = test_args[i + 1]
+                    i += 1
+                i += 1
+                
+    @patch('src.create_twitter_html_auto.main')
+    def test_main_html_with_short_k_option(self, mock_create_html):
+        """main.pyのhtmlコマンドで-k 短縮オプションをテスト"""
+        # テスト用のsys.argvを設定
+        test_args = ['main.py', 'html', '250513', '-k', 'en']
+
+        with patch('sys.argv', test_args):
+            # main.pyのhtmlコマンド部分をテスト
+            yymmdd = test_args[2]
+            if len(yymmdd) == 6:
+                year = 2000 + int(yymmdd[:2])
+                date_str = f"{year:04d}-{yymmdd[2:4]}-{yymmdd[4:6]}"
+            else:
+                date_str = None
+
+            # オプション解析
+            use_since = True
+            keyword_type = 'default'
+            search_keyword = None
+
+            i = 3
+            while i < len(test_args):
+                if test_args[i] == '--no-since':
+                    use_since = False
+                elif (test_args[i] == '--keyword-type' or test_args[i] == '-k') and i + 1 < len(test_args):
                     keyword_type = test_args[i + 1]
                     i += 1
                 elif test_args[i] == '--search-keyword' and i + 1 < len(test_args):
@@ -143,7 +175,7 @@ class TestIntegration(unittest.TestCase):
             # 結果を確認
             self.assertEqual(date_str, "2025-05-13")
             self.assertTrue(use_since)
-            self.assertEqual(keyword_type, 'chikirin')
+            self.assertEqual(keyword_type, 'en')
             self.assertIsNone(search_keyword)
 
     def test_search_query_actual_behavior(self):

--- a/tests/test_main_options.py
+++ b/tests/test_main_options.py
@@ -104,7 +104,7 @@ class TestMainOptions(unittest.TestCase):
             while i < len(test_args):
                 if test_args[i] == '--no-since':
                     use_since = False
-                elif test_args[i] == '--keyword-type' and i + 1 < len(test_args):
+                elif (test_args[i] == '--keyword-type' or test_args[i] == '-k') and i + 1 < len(test_args):
                     keyword_type = test_args[i + 1]
                     i += 1
                 elif test_args[i] == '--search-keyword' and i + 1 < len(test_args):
@@ -115,6 +115,32 @@ class TestMainOptions(unittest.TestCase):
             # 結果を確認
             self.assertTrue(use_since)
             self.assertEqual(keyword_type, 'en')
+            self.assertIsNone(search_keyword)
+    
+    def test_parse_html_options_short_k_option(self):
+        """-k 短縮オプションの解析テスト"""
+        test_args = ['main.py', 'html', '250706', '-k', 'chikirin']
+
+        with patch('sys.argv', test_args):
+            use_since = True
+            keyword_type = 'default'
+            search_keyword = None
+
+            i = 3
+            while i < len(test_args):
+                if test_args[i] == '--no-since':
+                    use_since = False
+                elif (test_args[i] == '--keyword-type' or test_args[i] == '-k') and i + 1 < len(test_args):
+                    keyword_type = test_args[i + 1]
+                    i += 1
+                elif test_args[i] == '--search-keyword' and i + 1 < len(test_args):
+                    search_keyword = test_args[i + 1]
+                    i += 1
+                i += 1
+
+            # 結果を確認
+            self.assertTrue(use_since)
+            self.assertEqual(keyword_type, 'chikirin')
             self.assertIsNone(search_keyword)
 
     def test_date_conversion(self):


### PR DESCRIPTION
## 変更内容
- `--keyword-type` の短縮形として `-k` オプションを追加
- テストケースを更新して `-k` オプションの動作を検証
- README に `-k` オプションの使い方を追記

## テスト
- [x] 既存のテストがすべてパスすることを確認
- [x] `-k` オプションで `--keyword-type` と同様に動作することを確認