### PR TITLE
feat: 保存済みマウス位置の選択を追加し、保存先をリポジトリ内に統一

### DIFF
--- a/config.py
+++ b/config.py
@@ -66,7 +66,9 @@ SEARCH_QUERY_TEMPLATE_WITHOUT_SINCE = '{until_datetime} {keyword}'
 
 # マウスポジション設定ファイルのパス
 import os
-CONFIG_DIR = os.path.expanduser("~/.config/twitter-html-extractor")
+# リポジトリ内に保存（data/config/positions.json）
+_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+CONFIG_DIR = os.path.join(_PROJECT_ROOT, 'data', 'config')
 POSITION_CONFIG_PATH = os.path.join(CONFIG_DIR, "positions.json")
 
 # デフォルトのマウスポジション設定


### PR DESCRIPTION
目的
- 手動で毎回位置を指定する手間を減らし、実行を安定・高速化するため
- 設定ファイルの所在をリポジトリ内に統一し、持ち運びや共有を容易にするため

変更点
- create_twitter_html_all.py
  - 位置取得前に「保存された位置を使用しますか？ [y/N]」の選択プロンプトを追加（TTYのみ）
  - 非TTY（テスト等）では自動的に保存済み位置を使用してブロックを回避
  - load_positions() を新パス専用に簡素化（旧パス互換を削除）
- config.py
  - 位置保存先を data/config/positions.json に変更（CONFIG_DIR/POSITION_CONFIG_PATH）
  - 旧パス定数（~/.config/...）を削除

影響範囲
- 通常実行・連続実行（-c/--continuous）ともに data/config/positions.json を参照・更新
- 旧パス（ホームディレクトリ配下）は非対応
- positions.json をVCS対象外にしたい場合は .gitignore に data/config/positions.json を追加推奨
