### PR TITLE
前日(JST)の自動適用（html/all）・自動化の高速化・README更新

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,9 @@ pytest --cov=src tests/
 ### 一括実行（推奨）
 
 ```bash
+# 日付省略（前日JSTを自動設定）
+python main.py all -k manekineko
+
 # 最新のツイートを取得（現在日時を使用）
 python main.py all --no-date -k manekineko
 
@@ -76,6 +79,9 @@ python main.py all 250831 -k manekineko -c 10
 # 基本形（日付指定）
 python main.py html 250706
 
+# 日付省略（前日JSTを自動設定）
+python main.py html -k chikirin
+
 # 日付指定なし（現在日時を使用）
 python main.py html --no-date
 
@@ -84,6 +90,7 @@ python main.py html 250706 -k chikirin
 ```
 
 - 指定日（例: 2025/07/06）の 0:00:00〜23:59:59 で検索
+- 日付未指定の場合は、前日（JST）の 0:00:00〜23:59:59 が自動設定されます
 - `--no-date` を指定すると、クリップボードから `until:YYYY-MM-DD_HH:MM:SS_JST` 形式の日時を取得
 - `--search-keyword` でカスタム検索キーワードを指定可能
 - `-k, --keyword-type` で事前に設定したキーワードタイプを指定可能
@@ -158,6 +165,9 @@ python main.py html 250803 -k chikirin
 # 基本形
 python main.py all 250706
 
+# 日付省略（前日JSTを自動設定）
+python main.py all -k manekineko
+
 # 日付指定なし（クリップボードから日時を取得）
 python main.py all --no-date
 
@@ -169,6 +179,7 @@ python main.py all 250706 -k chikirin
 ```
 
 - `all` サブコマンドはHTML作成と抽出を一括で実行
+- 日付未指定の場合は前日（JST）で実行
 - `--no-date` と併用すると、クリップボードから `until:YYYY-MM-DD_HH:MM:SS_JST` 形式の日時を取得
 - HTMLの作成とツイート抽出を一括で実行
 - 個別に `html` と `extract` を実行するのと同じ
@@ -305,6 +316,7 @@ python main.py html --no-date
 
 - **html コマンド**
   - `python main.py html <YYMMDD>`: 指定日付で検索・保存・抽出
+  - `python main.py html`: 日付省略時は前日（JST）で検索・保存・抽出
   - `python main.py html --no-date`: クリップボードの until 日時で検索・保存・抽出
   - `--keyword-type`, `--search-keyword` でキーワード指定可
 - **extract コマンド**
@@ -339,8 +351,8 @@ python main.py html --no-date
    - HTML ファイルの`datetime`属性を確認
    - タイムゾーン変換が正しく動作しているか確認
 4. **日付引数エラー**
-   - 日付は YYMMDD 形式（例：250706）で指定してください
-   - 通常の html コマンドでは日付引数が必須です
+   - 日付は YYMMDD 形式（例：250706）で指定できます
+   - 日付を省略すると、前日（JST）が自動的に設定されます（`html`/`all`）
 5. **--no-date オプションでエラー**
    - クリップボードに until 日時（until:YYYY-MM-DD_HH:MM:SS_JST 形式）が必要です
 
@@ -397,6 +409,7 @@ twitter-html-extractor/
 - エラーハンドリングを強化
 - 位置情報の保存/読み込み機能を追加
 - ログ出力を体系化し、デバッグを容易に
+- 日付未指定時に前日（JST）を自動設定（`html` / `all`）
 
 ### [1.0.0] - 2025-XX-XX
 

--- a/src/create_twitter_html_all.py
+++ b/src/create_twitter_html_all.py
@@ -82,7 +82,7 @@ def get_position(prompt, position_name, test_mode=False, use_saved=False, args=N
 
     # 保存された位置を確認
     positions = load_positions()
-    
+
     # 保存された位置があり、有効な座標の場合
     if use_saved and positions[position_name]['x'] > 0 and positions[position_name]['y'] > 0:
         return {
@@ -123,7 +123,7 @@ def navigate_to_twitter_search(search_query, search_box_pos):
     pyautogui.click(search_box_pos['x'], search_box_pos['y'])
     pyperclip.copy(search_query)
     pyautogui.hotkey('command', 'v')
-    time.sleep(0.5)
+    time.sleep(0.2)
     pyautogui.press('enter')
     time.sleep(1)  # 検索結果が表示されるのを待つ
 
@@ -131,7 +131,7 @@ def copy_html_with_extension(extension_button_pos):
     """ブラウザ拡張ボタンを押してHTMLをクリップボードにコピー"""
     # 拡張ボタンをクリック
     pyautogui.click(extension_button_pos['x'], extension_button_pos['y'])
-    time.sleep(1)  # コピーが完了するのを待つ
+    time.sleep(0.5)  # コピーが完了するのを待つ
 
     # クリップボードからHTMLを取得
     import pyperclip
@@ -477,7 +477,7 @@ def main(test_mode=False, date_str=None, search_keyword=None, use_date=True,
     )
 
     print("\n=== 自動化開始 ===")
-    time.sleep(0.5)
+    time.sleep(0.2)
 
     try:
         # Twitterの検索を実行
@@ -486,7 +486,7 @@ def main(test_mode=False, date_str=None, search_keyword=None, use_date=True,
 
         # ページの読み込みを待機
         print("ページの読み込みを待機中...")
-        time.sleep(2)
+        time.sleep(0.5)
 
         # ブラウザ拡張ボタンでHTMLをコピー
         print("HTMLをコピー中...")


### PR DESCRIPTION
## 概要\n- 日付未指定時に前日(JST)を自動適用（html/all）\n- 自動化の待機時間を短縮し応答性を改善\n- READMEに挙動を追記（使用例/仕様/FAQ/更新履歴）\n\n## 変更内容\n- feat(main): 日付未指定時は前日(JST)を自動適用（html/all）\n  - --no-date 未指定かつ日付引数なしの場合、JSTの前日を YYMMDD で自動設定\n  - --no-date の挙動は変更なし\n  - --verbose 時にINFO出力\n- perf(create_html): 待機時間短縮（0.5s→0.2s, 1s→0.5s, 2s→0.5s など）\n- docs(readme): 日付省略時の前日(JST)自動適用を明記し、例・仕様・FAQ・更新履歴を更新\n\n## 目的\n- 日次運用の手間削減と体感速度向上\n\n## 影響範囲\n- 仕様追加（デフォルト日付）・性能改善・ドキュメント\n- 既存の --no-date 挙動は変更なし\n\n## 動作確認\n- 2025-09-28 実行時に 2025-09-27 の since/until が自動設定\n- 自動化フローのタイミング短縮で正常動作を確認\n\n## 備考\n- data/config/positions.json はコミットから除外\n