### PR TITLE
feat: 複数キーワードタイプ処理とマウスポジション自動化機能を実装

### DIFF
--- a/config.py
+++ b/config.py
@@ -77,5 +77,24 @@ DEFAULT_POSITIONS = {
     'extension_button': {'x': 0, 'y': 0}  # 拡張ボタンの位置
 }
 
-# デバッグ設定
-DEBUG = False
+def save_mouse_positions_configured_flag(configured=True):
+    """マウスポジション設定済みフラグをファイルに保存する"""
+    try:
+        ensure_config_dir()
+        flag_path = os.path.join(CONFIG_DIR, "mouse_positions_configured.json")
+        with open(flag_path, 'w') as f:
+            json.dump({'configured': configured}, f)
+    except Exception as e:
+        print(f"警告: マウスポジション設定フラグの保存に失敗しました: {e}")
+
+def load_mouse_positions_configured_flag():
+    """マウスポジション設定済みフラグを読み込む"""
+    try:
+        flag_path = os.path.join(CONFIG_DIR, "mouse_positions_configured.json")
+        if os.path.exists(flag_path):
+            with open(flag_path, 'r') as f:
+                data = json.load(f)
+                return data.get('configured', False)
+    except Exception as e:
+        print(f"警告: マウスポジション設定フラグの読み込みに失敗しました: {e}")
+    return False


### PR DESCRIPTION

## 実装内容

カンマ区切りで複数キーワードタイプを同時指定可能にし、マウスポジション設定の自動化機能を実装しました。

### 変更点
- カンマ区切りで複数キーワードタイプを同時指定可能に（-kフラグ）
- マウスポジション設定後、2回目以降は自動的に保存位置を使用する機能を実装
- マウスポジション設定状態を永続化する設定フラグを追加
- ヘルプドキュメントに新機能の使用例を追加

BREAKING CHANGE: キーワードタイプ引数が複数値をサポートするよう変更
