### PR TITLE
fix: Twitter検索時のクリップボード操作のタイミング調整

### DIFF
--- a/src/create_twitter_html_all.py
+++ b/src/create_twitter_html_all.py
@@ -122,7 +122,6 @@ def navigate_to_twitter_search(search_query, search_box_pos):
     import pyperclip
     pyautogui.click(search_box_pos['x'], search_box_pos['y'])
     pyperclip.copy(search_query)
-    time.sleep(0.2)
     pyautogui.hotkey('command', 'v')
     time.sleep(0.2)
     pyautogui.press('enter')


### PR DESCRIPTION
検索クエリ貼り付け前のタイミング調整で安定性を向上

- 検索クエリ貼り付け前に0.2秒のスリープを追加
- クリップボードコピーと貼り付けのタイミング問題を解決