### PR TITLE
fix: X（Twitter）の検索不具合を回避するため、キーワードを個別に引用符で囲むよう修正

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,17 +5,16 @@
 """
 
 # デフォルトの検索キーワード
-DEFAULT_SEARCH_KEYWORD = 'dtv ビザ'
+DEFAULT_SEARCH_KEYWORD = '"dtv" "ビザ"'
 
 # 検索キーワードの定義
 SEARCH_KEYWORDS = {
-    'default': 'dtv ビザ',
-    'thai': 'dtv タイ',
-    'en': 'dtv visa',
+    'default': '"dtv" "ビザ"',
+    'thai': '"dtv" "タイ"',
+    'en': '"dtv" "visa"',
     'chikirin': '#ちきりんセレクトTV',
     'manekineko': 'from:thailandelitevi',
-    # 'intmax': 'lang:ja "intmax" マイニング or mining',
-    'intmax': 'lang:ja intmax',
+    'intmax': 'lang:ja "intmax"',
     'custom': None  # カスタムキーワード用
 }
 


### PR DESCRIPTION
### Context
Xの検索エンジンにおいて、スペース区切りのプレーンテキストを渡すと、キーワード間の論理関係（AND）が正しく解釈されない、あるいはトークナイズの不具合によってヒット率が低下する問題が発生しており、ユーザーより修正の依頼がありました。

### Proposed Changes
`config.py` 内の検索キーワード定義を修正し、各単語を個別に引用符で囲む形式に変更しました。
- `dtv ビザ` -> `"dtv" "ビザ"`
- `lang:ja intmax` -> `lang:ja "intmax"`
これにより、Xの検索エンジンに対してトークンの区切りを明示的に伝えます。

### Verification Results
- 修正後の `config.py` を読み込んで検索クエリが構築されることをコードレベルで確認済み。
- 主要な検索タイプ（default, thai, en, intmax）における引用符の付与状況を確認済み。