### PR TITLE
feat: chikirin抽出結果をObsidianへ同期

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -268,6 +268,15 @@ python main.py --html 250706 -k chikirin
 - 設定ファイルで定義されたキーワードタイプか、`--search-keyword` で直接キーワードを指定
 - `chikirin` などのキーワードタイプを指定すると、専用フォルダにファイルが保存され、データが整理されます
 
+`chikirin` の抽出に成功すると、抽出結果は自動的に次のObsidian Markdown表へ追記されます。
+
+`/Users/hiraku/Obsidian/hiraku-local/04_watch-list/watch list (text, audio, movie).md`
+
+- 既存のX投稿URLは重複登録しません
+- 作成日は投稿日時の `M/D`、種別は `movie` として登録します
+- 投稿本文とX投稿リンクを `contents` と `URL` 列へ登録します
+- Obsidianノートが利用できない場合も、抽出済みデータの保存処理は継続します
+
 ### キーワードタイプ別フォルダ機能
 
 キーワードタイプを指定すると、自動的に専用フォルダが作成され、データが分離管理されます：

--- a/src/append_chikirin_to_watch_list.py
+++ b/src/append_chikirin_to_watch_list.py
@@ -1,0 +1,82 @@
+"""ちきりんセレクトTVの取得結果をObsidianの視聴リストへ追記する。"""
+
+from datetime import datetime
+from pathlib import Path
+import re
+
+
+WATCH_LIST_PATH = Path(
+    "/Users/hiraku/Obsidian/hiraku-local/04_watch-list/"
+    "watch list (text, audio, movie).md"
+)
+
+
+def _escape_markdown_cell(value):
+    """Markdown表のセルとして安全な文字列にする。"""
+    return re.sub(r"\s+", " ", str(value or "")).strip().replace("|", "\\|")
+
+
+def _watch_date(datetime_value):
+    """抽出した日時を既存表の M/D 表記に変換する。"""
+    try:
+        return datetime.strptime(datetime_value, "%Y/%m/%d %H:%M:%S").strftime("%-m/%-d")
+    except (TypeError, ValueError):
+        return ""
+
+
+def _make_row(tweet):
+    """ツイート1件を既存の11列のMarkdown表行へ変換する。"""
+    text = _escape_markdown_cell(tweet.get("text"))
+    url = _escape_markdown_cell(tweet.get("quote_url"))
+    x_link = f"[X]({url})" if url else ""
+    cells = [
+        "ちきりん",
+        _watch_date(tweet.get("datetime")),
+        "movie",
+        "",
+        text,
+        "",
+        "",
+        "",
+        x_link,
+        "",
+        "",
+    ]
+    return "| " + " | ".join(cells) + " |\n"
+
+
+def append_chikirin_tweets(tweets, watch_list_path=WATCH_LIST_PATH):
+    """未登録のちきりん投稿を視聴リストの空行の前へ追記する。
+
+    Returns:
+        int: 実際に追記した投稿数。
+    """
+    path = Path(watch_list_path)
+    if not path.exists():
+        raise FileNotFoundError(f"視聴リストが見つかりません: {path}")
+
+    content = path.read_text(encoding="utf-8")
+    existing_urls = set(re.findall(r"https?://[^)\s<]+", content))
+    new_tweets = []
+    seen_urls = set()
+
+    for tweet in tweets:
+        url = (tweet.get("quote_url") or "").strip()
+        if not url or url in existing_urls or url in seen_urls:
+            continue
+        seen_urls.add(url)
+        new_tweets.append(tweet)
+
+    if not new_tweets:
+        return 0
+
+    rows = "".join(_make_row(tweet) for tweet in new_tweets)
+    lines = content.splitlines(keepends=True)
+    insert_at = len(lines)
+    for index, line in enumerate(lines):
+        if re.fullmatch(r"\|\s*(?:\|\s*){11}\n?", line):
+            insert_at = index
+            break
+    lines.insert(insert_at, rows)
+    path.write_text("".join(lines), encoding="utf-8")
+    return len(new_tweets)

--- a/src/extract_tweets_from_html.py
+++ b/src/extract_tweets_from_html.py
@@ -374,6 +374,23 @@ def save_tweets_to_files(tweets, base_filename="extracted_tweets", keyword_type=
 
     print(f"結果を {txt_path} と {json_path} に保存しました。")
 
+def append_chikirin_results_to_watch_list(tweets, keyword_type):
+    """ちきりんセレクトTVの取得結果をObsidianの視聴リストへ反映する。"""
+    if keyword_type != 'chikirin':
+        return
+
+    from src.append_chikirin_to_watch_list import append_chikirin_tweets
+
+    try:
+        appended_count = append_chikirin_tweets(tweets)
+    except OSError as e:
+        print(f"警告: 視聴リストへの追記に失敗しました: {e}")
+        return
+    if appended_count:
+        print(f"視聴リストに {appended_count} 件のちきりんセレクトTVを追記しました。")
+    else:
+        print("視聴リストに追記する未登録のちきりんセレクトTVはありません。")
+
 def main():
     """メイン処理"""
     # コマンドライン引数の解析
@@ -511,6 +528,7 @@ def main():
 
         # ツイートを抽出して保存
         save_tweets_to_files(tweets, output_filename, args.keyword_type)
+        append_chikirin_results_to_watch_list(tweets, args.keyword_type)
 
         # 結果を表示
         print("\n抽出されたツイート:")

--- a/tests/test_append_chikirin_to_watch_list.py
+++ b/tests/test_append_chikirin_to_watch_list.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from append_chikirin_to_watch_list import append_chikirin_tweets
+
+
+class TestAppendChikirinToWatchList(unittest.TestCase):
+    def setUp(self):
+        self.temp_file = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
+        self.temp_file.write(
+            "| person | create<br>date | type | title | contents | pri | watch<br>date | status | URL | comment | |\n"
+            "| :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | --- |\n"
+            "| 既存 | | movie | | | | | | [X](https://x.com/a/status/1) | | |\n"
+            "| | | | | | | | | | | |\n"
+        )
+        self.temp_file.close()
+
+    def tearDown(self):
+        os.unlink(self.temp_file.name)
+
+    def test_appends_new_tweets_before_empty_rows_and_skips_duplicates(self):
+        tweets = [
+            {
+                "datetime": "2026/07/20 18:53:32",
+                "text": "番組の感想 | 補足\n改行あり",
+                "quote_url": "https://x.com/InsideCHIKIRIN/status/2",
+            },
+            {
+                "datetime": "2026/07/20 18:54:50",
+                "text": "既存投稿",
+                "quote_url": "https://x.com/a/status/1",
+            },
+        ]
+
+        self.assertEqual(append_chikirin_tweets(tweets, self.temp_file.name), 1)
+        self.assertEqual(append_chikirin_tweets(tweets, self.temp_file.name), 0)
+
+        with open(self.temp_file.name, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("| ちきりん | 7/20 | movie |  | 番組の感想 \\| 補足 改行あり", content)
+        self.assertLess(content.index("InsideCHIKIRIN/status/2"), content.index("| | | | | | | | | | | |"))


### PR DESCRIPTION
## 概要
- `chikirin` の抽出成功時に、取得した投稿を指定のObsidian Markdown表へ自動追記
- Markdown表のセルエスケープ、既存X URLによる重複排除、末尾の空行前への挿入を実装
- Obsidianノートへの追記失敗時も、抽出結果のファイル保存は継続
- READMEと追記処理のユニットテストを追加

## 背景
これまで `chikirin` の抽出結果はJSON/TXTへ保存されていましたが、視聴リストへの転記が手作業でした。抽出成功時に既存のMarkdown表へ同期することで、取得から一覧管理までの運用を自動化します。

## 実装内容
- `src/append_chikirin_to_watch_list.py` を追加
  - 投稿日時を既存形式の `M/D` へ変換
  - `ちきりん`、`movie`、投稿本文、`[X](...)` リンクを対応列へ登録
  - URLをキーに既存行および同一実行内の重複を除外
  - Markdown表の既存空行を保持したまま追記
- `src/extract_tweets_from_html.py` から `chikirin` の抽出成功後に呼び出し
- `docs/README.md` に同期仕様を追記

## 影響範囲
- `chikirin` キーワードの抽出後処理
- 指定されたローカルObsidianノート
- その他のキーワードタイプの抽出処理には影響なし

## 確認
- `python3 -m unittest tests.test_append_chikirin_to_watch_list tests.test_extract_tweets`
- `python3 -m py_compile src/extract_tweets_from_html.py src/append_chikirin_to_watch_list.py`
- `git diff --cached --check`
- 既取得の6件を実ノートへ反映し、再実行時に重複登録されないことを確認済み
