### PR TITLE
fix: X検索入力と詳細タブ終了処理を安定化

### DIFF
--- a/src/create_twitter_html_all.py
+++ b/src/create_twitter_html_all.py
@@ -119,15 +119,25 @@ def navigate_to_twitter_search(search_query, search_box_pos):
     # 検索ボックスをクリックしてフォーカス
     pyautogui.click(search_box_pos['x'], search_box_pos['y'])
     time.sleep(config.WAIT_SECONDS['after_search_box_click'])
-    # ×ボタンをクリックして検索をクリア
+
+    # 検索欄右端の×ボタンをクリックして既存の検索文字列をクリアする。
+    # ここではcmd+Aを使わない。座標クリック後にフォーカスが外れていると
+    # ページ全体が選択されるため、従来どおり×ボタン操作に任せる。
     pyautogui.click(search_box_pos['x'], search_box_pos['y'])
     time.sleep(config.WAIT_SECONDS['after_search_clear_click'])
 
-    # 検索クエリをクリップボードにコピーして貼り付け
-    pyautogui.click(search_box_pos['x'], search_box_pos['y'])
+    # クリップボードへのコピー完了を確認してから、検索欄へ貼り付ける。
+    # hotkey() ではCommandの押下とvの送信が近すぎて、環境によっては
+    # Commandが認識されず「v」だけが検索欄へ入力されることがある。
     pyperclip.copy(search_query)
     time.sleep(config.WAIT_SECONDS['after_clipboard_copy'])
-    pyautogui.hotkey('command', 'v')
+    if pyperclip.paste() != search_query:
+        pyperclip.copy(search_query)
+        time.sleep(config.WAIT_SECONDS['after_clipboard_copy'])
+
+    pyautogui.click(search_box_pos['x'], search_box_pos['y'])
+    time.sleep(config.WAIT_SECONDS['after_search_box_click'])
+    paste_clipboard()
     time.sleep(config.WAIT_SECONDS['after_search_paste'])
     pyautogui.press('enter')
     time.sleep(config.WAIT_SECONDS['search_results_load'])  # 検索結果が表示されるのを待つ
@@ -192,7 +202,9 @@ def close_detail_tab():
     # 先にEscapeでポップアップを閉じてからタブを閉じる。
     pyautogui.press('esc')
     time.sleep(config.WAIT_SECONDS['before_extension_click'])
-    pyautogui.hotkey('command', 'w')
+    # hotkey() ではCommandの認識前にwが送られる場合があるため、
+    # 検索入力と同じくキーイベントを明示的に分ける。
+    press_chrome_shortcut('w')
     time.sleep(config.WAIT_SECONDS['after_tab_close'])
 
 
@@ -267,13 +279,13 @@ def process_detail_pages(tweets_data, search_box_pos, extension_button_pos, date
 
                 if not html_content:
                     print("詳細ページからHTMLの取得に失敗しました")
+                    close_detail_tab()
                     continue
 
                 is_detail_html, detail_message, soup = validate_detail_html_for_tweet(html_content, tweet_url)
                 if not is_detail_html:
                     print(f"警告: {detail_message}")
-                    if '/search?' not in detail_message:
-                        close_detail_tab()
+                    close_detail_tab()
                     continue
 
                 print(f"詳細ページHTMLを確認しました: {detail_message}")

--- a/tests/test_navigate.py
+++ b/tests/test_navigate.py
@@ -8,11 +8,15 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 
 class TestNavigateToTwitterSearch(unittest.TestCase):
     @patch('pyautogui.click')
-    @patch('pyautogui.hotkey')
+    @patch('pyautogui.keyDown')
+    @patch('pyautogui.keyUp')
     @patch('pyautogui.press')
     @patch('pyperclip.copy')
+    @patch('pyperclip.paste', return_value='test query')
     @patch('time.sleep')
-    def test_navigate_to_twitter_search(self, mock_sleep, mock_copy, mock_press, mock_hotkey, mock_click):
+    def test_navigate_to_twitter_search(self, mock_sleep, mock_paste, mock_copy,
+                                        mock_press, mock_key_up, mock_key_down,
+                                        mock_click):
         # テスト対象の関数を動的にインポート
         from create_twitter_html_all import navigate_to_twitter_search
         
@@ -24,15 +28,17 @@ class TestNavigateToTwitterSearch(unittest.TestCase):
         navigate_to_twitter_search(search_query, search_box_pos)
         
         # 検証
-        # 1. 検索ボックスを3回クリック
+        # 1. 検索欄へのフォーカス、×ボタンでのクリア、貼り付け前の再フォーカス
         self.assertEqual(mock_click.call_count, 3)
         mock_click.assert_any_call(100, 200)
         
         # 2. クリップボードにコピー
         mock_copy.assert_called_once_with("test query")
         
-        # 3. ペースト
-        mock_hotkey.assert_called_once_with('command', 'v')
+        # 3. Commandを押した状態でvを送り、確実に解放する
+        mock_key_down.assert_any_call('command')
+        mock_key_up.assert_any_call('command')
+        mock_press.assert_any_call('v')
         
         # 4. 残ったポップアップを閉じてからEnterキー
         mock_press.assert_any_call('esc')


### PR DESCRIPTION
## 概要

X検索時の貼り付け不具合と、詳細ページ処理後にタブが残る問題を修正しました。

## 背景

検索クエリの入力で `pyautogui.hotkey('command', 'v')` を使用していたため、Commandの認識より先に `v` が入力され、検索欄に `v` だけが残るケースがありました。

また、詳細ページのHTML取得失敗時や検索一覧HTMLが返った時に、リトライへ進む前の詳細タブを閉じない経路がありました。

## 実装内容

- `src/create_twitter_html_all.py`
  - 検索欄の既存文字列クリアは従来どおり×ボタンの2クリック操作を維持
  - 検索クエリのクリップボード内容を確認してから貼り付け
  - Commandの押下・`v`入力・解放を明示的に分離
  - 詳細タブを閉じる操作も明示的なCommandショートカットへ変更
  - 詳細HTML取得失敗時および検索一覧HTML検出時にもタブを閉じてからリトライ
- `tests/test_navigate.py`
  - 明示的なCommandキー操作と、従来の3回クリック操作を検証
  - クリップボード内容の確認処理をモック

## 影響範囲

- X検索クエリの入力安定性
- 「さらに表示」対象ツイートの詳細ページ抽出
- 詳細ページ取得リトライ時のブラウザタブ状態

検索クエリの生成、HTML保存、通常のツイート抽出、CSVマージの仕様には変更ありません。

## 確認

- `python3 -m pytest tests/test_navigate.py -q`
- `python3 -m py_compile src/create_twitter_html_all.py`
- `git diff --check`
- 全体テスト: 53 passed / 8 failed（既存の引数解析・連続実行・`--no-date`系テストおよびテスト間モック状態依存）

ブラウザを実際に操作するE2E確認は未実施です。
